### PR TITLE
Enhance student tags API documentation and add proficiency levels for…

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,5 +21,9 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        $this->call([
+            TagSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/TagSeeder.php
+++ b/database/seeders/TagSeeder.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Tag;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class TagSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $softwareEngineeringTags = [
+            // Programming Languages
+            ['name' => 'PHP', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'JavaScript', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'TypeScript', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Python', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Java', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'C#', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'C++', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Go', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Rust', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Ruby', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Swift', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Kotlin', 'tag_type' => 'skill', 'is_active' => true],
+
+            // Frontend Frameworks
+            ['name' => 'React', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Vue.js', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Angular', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Svelte', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Next.js', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Nuxt.js', 'tag_type' => 'skill', 'is_active' => true],
+
+            // Backend Frameworks
+            ['name' => 'Laravel', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Node.js', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Express.js', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Django', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Flask', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Spring Boot', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'ASP.NET', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Ruby on Rails', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'FastAPI', 'tag_type' => 'skill', 'is_active' => true],
+
+            // Databases
+            ['name' => 'MySQL', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'PostgreSQL', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'MongoDB', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Redis', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'SQLite', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'SQL Server', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Oracle', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Elasticsearch', 'tag_type' => 'skill', 'is_active' => true],
+
+            // DevOps & Cloud
+            ['name' => 'Docker', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Kubernetes', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'AWS', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Azure', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Google Cloud', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'CI/CD', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Jenkins', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'GitHub Actions', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Terraform', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Ansible', 'tag_type' => 'skill', 'is_active' => true],
+
+            // Version Control
+            ['name' => 'Git', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'GitHub', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'GitLab', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Bitbucket', 'tag_type' => 'skill', 'is_active' => true],
+
+            // Mobile Development
+            ['name' => 'React Native', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Flutter', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'iOS Development', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Android Development', 'tag_type' => 'skill', 'is_active' => true],
+
+            // Testing
+            ['name' => 'Unit Testing', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Integration Testing', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Jest', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'PHPUnit', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Selenium', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Cypress', 'tag_type' => 'skill', 'is_active' => true],
+
+            // Methodologies & Practices
+            ['name' => 'Agile', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Scrum', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'REST API', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'GraphQL', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Microservices', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'TDD', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Clean Code', 'tag_type' => 'skill', 'is_active' => true],
+
+            // AI & Data Science
+            ['name' => 'Machine Learning', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Deep Learning', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Data Science', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'TensorFlow', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'PyTorch', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Natural Language Processing', 'tag_type' => 'skill', 'is_active' => true],
+
+            // Web Technologies
+            ['name' => 'HTML', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'CSS', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'SASS/SCSS', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Tailwind CSS', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Bootstrap', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Webpack', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Vite', 'tag_type' => 'skill', 'is_active' => true],
+
+            // Security
+            ['name' => 'Cybersecurity', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'OAuth', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'JWT', 'tag_type' => 'skill', 'is_active' => true],
+            ['name' => 'Penetration Testing', 'tag_type' => 'skill', 'is_active' => true],
+
+            // Industry/Role Types
+            ['name' => 'Software Development', 'tag_type' => 'industry', 'is_active' => true],
+            ['name' => 'Web Development', 'tag_type' => 'industry', 'is_active' => true],
+            ['name' => 'Mobile Development', 'tag_type' => 'industry', 'is_active' => true],
+            ['name' => 'DevOps', 'tag_type' => 'industry', 'is_active' => true],
+            ['name' => 'Data Engineering', 'tag_type' => 'industry', 'is_active' => true],
+            ['name' => 'Cloud Engineering', 'tag_type' => 'industry', 'is_active' => true],
+            ['name' => 'Full Stack Development', 'tag_type' => 'industry', 'is_active' => true],
+            ['name' => 'Frontend Development', 'tag_type' => 'industry', 'is_active' => true],
+            ['name' => 'Backend Development', 'tag_type' => 'industry', 'is_active' => true],
+            ['name' => 'QA/Testing', 'tag_type' => 'industry', 'is_active' => true],
+            ['name' => 'IT Support', 'tag_type' => 'industry', 'is_active' => true],
+            ['name' => 'Network Engineering', 'tag_type' => 'industry', 'is_active' => true],
+            ['name' => 'System Administration', 'tag_type' => 'industry', 'is_active' => true],
+
+            // Education Levels / Majors
+            ['name' => 'Computer Science', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Software Engineering', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Information Technology', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Information Systems', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Computer Engineering', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Electrical Engineering', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Data Science', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Cybersecurity', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Artificial Intelligence', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Network Administration', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Web Development', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Game Development', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Database Administration', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Business Informatics', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Applied Computing', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Digital Media', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Interactive Media', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Mechatronics', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Robotics', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Mathematics', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Statistics', 'tag_type' => 'major', 'is_active' => true],
+            ['name' => 'Physics', 'tag_type' => 'major', 'is_active' => true],
+
+            // Personality Traits
+            ['name' => 'Creative', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Social', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Leadership', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Analytical', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Detail-oriented', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Problem Solver', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Team Player', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Independent', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Self-motivated', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Adaptable', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Communicative', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Organized', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Curious', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Innovative', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Patient', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Persistent', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Proactive', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Reliable', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Resourceful', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Strategic Thinker', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Critical Thinker', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Fast Learner', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Collaborative', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Empathetic', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Enthusiastic', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Flexible', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Goal-oriented', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Humble', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Open-minded', 'tag_type' => 'trait', 'is_active' => true],
+            ['name' => 'Positive Attitude', 'tag_type' => 'trait', 'is_active' => true],
+        ];
+
+        foreach ($softwareEngineeringTags as $tag) {
+            Tag::firstOrCreate(
+                ['name' => $tag['name']],
+                $tag
+            );
+        }
+    }
+}
+

--- a/docs/API.md
+++ b/docs/API.md
@@ -1167,14 +1167,15 @@ Replaces all languages for the student. Send the complete list of languages.
 | **Path** | `/student/tags` |
 | **Auth** | Bearer token + student role |
 
-Replaces all tags/skills for the student. Send the complete list of tags.
+Replaces all tags/skills for the student. Send the complete list of tags. This is a **sync** operation—existing tags are removed and replaced with the new list provided.
 
 **Request body:**
 ```json
 {
   "tags": [
-    { "tag_id": 1, "is_active": true, "weight": 5 },
-    { "tag_id": 2, "weight": 3 }
+    { "tag_id": 1, "is_active": true, "weight": 95 },
+    { "tag_id": 2, "is_active": true, "weight": 85 },
+    { "tag_id": 13, "is_active": true, "weight": 70 }
   ]
 }
 ```
@@ -1186,7 +1187,98 @@ Replaces all tags/skills for the student. Send the complete list of tags.
 | tags.*.is_active | boolean | No | Defaults to true |
 | tags.*.weight | number | No | 0–100, represents proficiency/priority |
 
-**Success (200):** `{ "message": "Tags updated successfully.", "data": [...], "links": {...} }`
+#### Understanding the `weight` field
+
+The `weight` field (0–100) represents the student's **proficiency level** for that skill/tag:
+
+| Weight Range | Proficiency Level |
+|--------------|-------------------|
+| 90–100 | Expert |
+| 70–89 | Advanced |
+| 50–69 | Intermediate |
+| 30–49 | Beginner |
+| 0–29 | Learning |
+
+This weight is used by the matching algorithm to better match students with vacancies. A higher weight indicates stronger proficiency.
+
+**Example – Adding skills with proficiency levels:**
+```json
+{
+  "tags": [
+    { "tag_id": 19, "is_active": true, "weight": 95 },
+    { "tag_id": 1, "is_active": true, "weight": 90 },
+    { "tag_id": 13, "is_active": true, "weight": 60 },
+    { "tag_id": 4, "is_active": true, "weight": 40 }
+  ]
+}
+```
+In this example, the student is an expert in tag 19 (e.g., Laravel), advanced in tag 1 (e.g., PHP), intermediate in tag 13 (e.g., React), and a beginner in tag 4 (e.g., Python).
+
+**Success (200):**
+```json
+{
+  "message": "Tags updated successfully.",
+  "data": [
+    {
+      "tag_id": 19,
+      "is_active": true,
+      "weight": 95,
+      "tag": { "id": 19, "name": "Laravel", "tag_type": "skill" }
+    },
+    {
+      "tag_id": 1,
+      "is_active": true,
+      "weight": 90,
+      "tag": { "id": 1, "name": "PHP", "tag_type": "skill" }
+    }
+  ],
+  "links": { "self": "https://<your-api-host>/api/v1/student/tags" }
+}
+```
+
+**Error responses:**
+
+| Status | Reason |
+|--------|--------|
+| 401 | Not authenticated (missing or invalid JWT) |
+| 403 | User is not a student |
+| 422 | Validation error (invalid tag_id, weight out of range, etc.) |
+
+<details>
+<summary><strong>Postman example</strong></summary>
+
+1. **Login as a student** to get a JWT token:
+   ```
+   POST /api/v1/auth/login
+   Content-Type: application/json
+   
+   { "email": "student@example.com", "password": "password123" }
+   ```
+
+2. **Sync tags** with the token:
+   ```
+   PUT /api/v1/student/tags
+   Authorization: Bearer <your-jwt-token>
+   Content-Type: application/json
+   Accept: application/json
+   
+   {
+     "tags": [
+       { "tag_id": 1, "is_active": true, "weight": 90 },
+       { "tag_id": 2, "is_active": true, "weight": 85 },
+       { "tag_id": 19, "is_active": true, "weight": 95 }
+     ]
+   }
+   ```
+
+3. **Verify** by listing tags:
+   ```
+   GET /api/v1/student/tags
+   Authorization: Bearer <your-jwt-token>
+   Accept: application/json
+   ```
+
+</details>
 
 [↑ Back to index](#index)
 


### PR DESCRIPTION
This pull request introduces a comprehensive tag seeding system for software engineering, expands the database seeder to include tag data, and significantly improves API documentation for student tag management. The main changes are the addition of a detailed `TagSeeder`, the integration of this seeder into the database seeding workflow, and clearer documentation for tag proficiency and API behavior.

**Tag seeding and database integration:**

* Added a new `TagSeeder` class in `database/seeders/TagSeeder.php` that seeds a wide range of tags, including skills, industries, majors, and personality traits relevant to software engineering. Each tag includes a type and active status.
* Updated `DatabaseSeeder.php` to call the new `TagSeeder`, ensuring tags are seeded alongside user data during database setup.

**API documentation improvements:**

* Enhanced `docs/API.md` to clarify that the `/student/tags` endpoint replaces all tags in a sync operation, removing old tags and setting the new list.
* Added a detailed explanation of the `weight` field in `docs/API.md`, including proficiency levels, example payloads, and how weights impact student-vacancy matching.
* Provided example success and error responses, plus a step-by-step Postman usage guide for syncing and verifying student tags in `docs/API.md`.… tags