### PR TITLE
feature/us-34 Student is now able to save their favourite companies

### DIFF
--- a/app/Http/Controllers/Api/Student/StudentFavoriteCompanyController.php
+++ b/app/Http/Controllers/Api/Student/StudentFavoriteCompanyController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers\Api\Student;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Student\StoreStudentFavoriteCompanyRequest;
+use App\Models\StudentFavoriteCompany;
+use Illuminate\Http\Request;
+
+class StudentFavoriteCompanyController extends Controller
+{
+    public function index(Request $request)
+    {
+        $user = auth('api')->user();
+
+        $favorites = StudentFavoriteCompany::query()
+            ->with('company')
+            ->where('student_user_id', $user->id)
+            ->latest('created_at')
+            ->get();
+
+        return response()->json([
+            'data' => $favorites,
+            'links' => [
+                'self' => url('/api/v1/student/favorite-companies'),
+            ],
+        ]);
+    }
+
+    public function store(StoreStudentFavoriteCompanyRequest $request)
+    {
+        $user = auth('api')->user();
+        $companyId = $request->validated()['company_id'];
+
+        $favorite = StudentFavoriteCompany::query()->firstOrCreate([
+            'student_user_id' => $user->id,
+            'company_id' => $companyId,
+        ], [
+            'created_at' => now(),
+        ]);
+
+        return response()->json([
+            'message' => 'Company added to favorites.',
+            'data' => $favorite,
+            'links' => [
+                'self' => url("/api/v1/student/favorite-companies/{$companyId}"),
+                'collection' => url('/api/v1/student/favorite-companies'),
+            ],
+        ], 201);
+    }
+
+    public function destroy(int $companyId)
+    {
+        $user = auth('api')->user();
+
+        $deleted = StudentFavoriteCompany::query()
+            ->where('student_user_id', $user->id)
+            ->where('company_id', $companyId)
+            ->delete();
+
+        if ($deleted === 0) {
+            return response()->json([
+                'message' => 'Favorite company not found.',
+            ], 404);
+        }
+
+        return response()->json([
+            'message' => 'Company removed from favorites.',
+        ]);
+    }
+}

--- a/app/Http/Requests/Student/StoreStudentFavoriteCompanyRequest.php
+++ b/app/Http/Requests/Student/StoreStudentFavoriteCompanyRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Student;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreStudentFavoriteCompanyRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'company_id' => ['required', 'integer', 'exists:companies,id'],
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Api\StageCoordinatorUserController;
 use App\Http\Controllers\Api\Student\StudentProfileController;
 use App\Http\Controllers\Api\TagController;
 use App\Http\Controllers\Api\VacancyController;
+use App\Http\Controllers\Api\Student\StudentFavoriteCompanyController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->group(function () {
@@ -71,6 +72,11 @@ Route::prefix('v1')->group(function () {
             // Languages (sync)
             Route::get('student/languages', [StudentProfileController::class, 'listLanguages']);
             Route::put('student/languages', [StudentProfileController::class, 'syncLanguages']);
+
+            // Favorite companies (add/remove)
+            Route::get('student/favorite-companies', [StudentFavoriteCompanyController::class, 'index']);
+            Route::post('student/favorite-companies', [StudentFavoriteCompanyController::class, 'store']);
+            Route::delete('student/favorite-companies/{companyId}', [StudentFavoriteCompanyController::class, 'destroy']);
 
             // Tags/Skills (sync)
             Route::get('student/tags', [StudentProfileController::class, 'listTags']);


### PR DESCRIPTION
Test requirements :

Register or login as a coordinator

Create at least 1 company

Create a student

Login as that student


Benodigde Headers :

Authorization: Bearer <JWT> 
Content-Type: application/json 
Accept: application/json


GET favoriete bedrijven :

Endpoint:

GET /api/v1/student/favorite-companies

Expected response:

200 OK

Example response:

{
  "data": [],
  "links": {
    "self": "/api/v1/student/favorite-companies"
  }
}
(voor een nieuw student is de output leeg)


Favoriete bedrijven opslaan :

Endpoint:

POST /api/v1/student/favorite-companies

Example request body:

{
  "company_id": 1
}

Expected response:

201 Created

Example response:

{
  "message": "Company added to favorites.",
  "data": {
    "student_user_id": 5,
    "company_id": 1,
    "created_at": "2026-03-10T12:00:00Z"
  },
  "links": {
    "self": "/api/v1/student/favorite-companies/1",
    "collection": "/api/v1/student/favorite-companies"
  }
}

DELETE favoriete bedrijven :

Endpoint:

DELETE /api/v1/student/favorite-companies/{companyId}

Example:

DELETE /api/v1/student/favorite-companies/1

Expected response:

200 OK

Example response:

{
  "message": "Company removed from favorites."
}

Je kan delete testen door het nog een keer te doen, als het gelukt is, moet die een error aangeven van dat het item niet bestaat